### PR TITLE
Allow setting job-specific slow threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,10 +126,31 @@ Notable.mask_ips = true
 
 ### Jobs
 
-Set slow threshold
+Set general slow threshold
 
 ```ruby
 Notable.slow_job_threshold = 60 # seconds (default)
+```
+
+
+Set a custom slow threshold (job-specific)
+
+Implement `notable_runtime_threshold` as a method in the job class. It should return the maximum threshold in seconds, for that job class.
+
+If this isn't set, the default threshold set using `Notable.slow_job_threshold`, is used.
+
+In the example below, when CustomJob is run, the threshold used to measure whether it's classified as a Slow request or not is 100 seconds.
+
+```ruby
+class CustomJob < ApplicationJob
+  def perform
+    ...
+  end
+
+  def notable_runtime_threshold
+    100
+  end
+end
 ```
 
 Custom track method

--- a/lib/notable.rb
+++ b/lib/notable.rb
@@ -69,7 +69,7 @@ module Notable
     RequestStore.store.delete(:notable_notes)
   end
 
-  def self.track_job(job, job_id, queue, created_at)
+  def self.track_job(job, job_id, queue, created_at, runtime_threshold)
     exception = nil
     notes = nil
     start_time = Time.now
@@ -86,7 +86,7 @@ module Notable
     runtime = Time.now - start_time
 
     Safely.safely do
-      notes << {note_type: "Slow Job"} if runtime > Notable.slow_job_threshold
+      notes << {note_type: "Slow Job"} if runtime > runtime_threshold
 
       notes.each do |note|
         data = {

--- a/lib/notable/job_extensions.rb
+++ b/lib/notable/job_extensions.rb
@@ -5,9 +5,13 @@ module Notable
     included do
       around_perform do |job, block|
         # no way to get queued_at time :(
-        Notable.track_job(job.class.name, job.job_id, job.queue_name, nil) do
+        Notable.track_job(job.class.name, job.job_id, job.queue_name, nil, notable_runtime_threshold) do
           block.call
         end
+      end
+
+      def notable_runtime_threshold
+        Notable.slow_job_threshold
       end
     end
   end


### PR DESCRIPTION
Ran into a use-case where some deliberate long-running jobs caused always triggered a Slow Job record.

With this, users are able to set a job-specific threshold in seconds, to override the globally-set runtime threshold.